### PR TITLE
增加调试脚本，错误日志输出更改，增加付费token上传模式

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc -p .",
-    "dev": "tsc -w -p ."
+    "dev": "tsc -w -p .",
+    "install": "picgo install . && picgo use uploader",
+    "set": "picgo set uploader",
+    "upload":"picgo -d upload D:\\图片\\0-test.jpg"
   },
   "keywords": [
     "picgo",
@@ -30,7 +33,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.0",
     "eslint-plugin-standard": "^3.1.0",
-    "picgo": "^1.5.0-alpha.13",
+    "picgo": "^1.5.7",
     "typescript": "^4.8.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,7 @@
   "homepage": "https://github.com/wuuconix/picgo-plugin-superbed-uploader",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc -p .",
-    "dev": "tsc -w -p .",
-    "install": "picgo install . && picgo use uploader",
-    "set": "picgo set uploader",
-    "upload":"picgo -d upload D:\\图片\\0-test.jpg"
+    "build": "tsc -p ."
   },
   "keywords": [
     "picgo",


### PR DESCRIPTION
添加了详细的调试脚本，仅在开发时使用，生产环境请删除
修改了日志输出，以便在上传失败时可以看到更详细的错误原因
原上传函数由于某种原因已经不可用，我只增加了付费token上传，免费用户使用token直接上传会报错